### PR TITLE
Fixed Opposite movement direction bug

### DIFF
--- a/space_adventure.py
+++ b/space_adventure.py
@@ -82,9 +82,9 @@ class Player(pygame.sprite.Sprite):
         self.speed_x = 0
         keystate = pygame.key.get_pressed()
         if keystate[pygame.K_LEFT]:
-            self.speed_x = 8
-        if keystate[pygame.K_RIGHT]:
             self.speed_x = -8
+        if keystate[pygame.K_RIGHT]:
+            self.speed_x = 8
 
         self.rect.x += self.speed_x
         if self.rect.right > SCREEN_WIDTH + 20:


### PR DESCRIPTION
The movement of the player is to the opposite direction of the key press.
Ex : When left is pressed moves right

fixed the issue successfully